### PR TITLE
Add GitHub Skills Activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of the GitHub Certifications program to help with college applications",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds the missing **GitHub Skills** activity that was announced by the principal but was not available in the system.

## Changes Made
- Added "GitHub Skills" to the activities dictionary in `app.py`
- Schedule: Wednesdays, 3:30 PM - 5:00 PM
- Maximum capacity: 25 students
- Description includes reference to GitHub Certifications program for college applications

## Addresses
Fixes #6 

## Context
This is a time-sensitive addition as registrations were announced to close by the end of this week. Students have been unable to find this activity on the signup page despite the principal's announcement about the GitHub partnership.

## Testing
- ✅ Python syntax validated
- ✅ Activity structure matches existing activities
- ✅ Ready for student registrations